### PR TITLE
Add an example that get the plugin gem from local file system

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ Add this line to your application's Gemfile:
 gem 'miq_plugin_example'
 ```
 
+Or, if you prefer to work using local directory:
+
+```ruby
+gem 'miq_plugin_example', :path => File.expand_path('[ PATH TO PLUGIN e.g. ../plugins ]/miq_plugin_example', __dir__)
+```
+
 And then execute:
 ```bash
 $ bundle


### PR DESCRIPTION
**Descritopns**
Add an example that get the plugin gem from local file system

**Motive**
For development I put this plugin in my local `manageiq/plugins` directory, and added it to my .`../bundler.d/Gemfile.dev.rb` file, I think it's more fun.